### PR TITLE
Adiciona endereço do feed RSS para a página

### DIFF
--- a/beerapp/templates/layout/base.html
+++ b/beerapp/templates/layout/base.html
@@ -7,6 +7,9 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>TeresinaHC Planet</title>
 
+    <!-- Feed RSS -->
+    <link rel="alternate" type="application/rss+xml" title="TeresinaHC Planet Feed RSS" href="/feed/rss" />
+
     <!-- Bootstrap -->
     <link href="/static/css/bootstrap.min.css" rel="stylesheet">
     <link href="/static/css/bootstrap-theme.min.css" rel="stylesheet">
@@ -48,7 +51,7 @@
     </div>
 
     <footer>
-      <p>TeresinaHC Planet - <a href="https://github.com/teresinahc/planet">Github</a></p>
+      <p>TeresinaHC Planet - <a href="/feed/rss">Feed</a> - <a href="https://github.com/teresinahc/planet">Github</a></p>
     </footer>
 
   </body>


### PR DESCRIPTION
O código do beerapp já gera um feed RSS e outro Atom para os posts, mas o endereço para eles não era apresentado nas páginas do site, ficando escondido dos visitantes e inclusive dos navegadores.

Com essa alteração o endereço para o feed RSS está visível e é também identificado pelos browsers.
