### PR TITLE
Altera configurações do feed para TeresinaHC

### DIFF
--- a/beerapp/settings/settings_common.py
+++ b/beerapp/settings/settings_common.py
@@ -1,7 +1,7 @@
 PAGINATION_ITEMS_PER_PAGE = 5
 
-FEED_TITLE = "BeerBlogging"
-FEED_LINK = "http://www.beerblogging.io"
-FEED_AUTHOR = "BeerBlogging Team"
-FEED_DESC = "Posts from all beerbloggers"
+FEED_TITLE = "Planet TeresinaHC"
+FEED_LINK = "http://planet.teresinahc.org"
+FEED_AUTHOR = "Planet TeresinaHC Team"
+FEED_DESC = "Posts from all TeresinaHC hackers"
 FEED_ITEMS = 10


### PR DESCRIPTION
Altera configurações que identificam o feed do BeerBlogging, como título
e link do feed, para configurações que identificam o Planet TeresinaHC.
